### PR TITLE
Add a word screen

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,13 @@
 {
   "parser": "babel-eslint",
   "extends": ["airbnb", "prettier", "prettier/react"],
-  "plugins": ["react", "jsx-a11y", "import", "eslint-plugin-prettier"],
+  "plugins": [
+    "react",
+    "jsx-a11y",
+    "import",
+    "eslint-plugin-prettier",
+    "eslint-plugin-react"
+  ],
   "rules": {
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/prefer-default-export": "off",
@@ -27,9 +33,9 @@
         "trailingComma": "none",
         "singleQuote": true,
         "jsxSingleQuote": false,
-        "printWidth": 160,
+        "printWidth": 100,
         "semi": true,
-        "proseWrap": "preserve"
+        "jsxBracketSameLine": true
       }
     ]
   },

--- a/src/components/AppHeader/AppHeader.js
+++ b/src/components/AppHeader/AppHeader.js
@@ -9,18 +9,20 @@ class AppHeader extends Component {
   render() {
     return (
       <Header style={styles.headerBar} iosBarStyle="dark-content" androidStatusBarColor="lightgray">
-        <Left>
+        <Left style={{ flex: 2 }}>
           <TouchableHighlight style={styles.profileImgContainer}>
             <Image source={{ uri: this.props.googleUser.photo }} style={styles.profileImg} />
           </TouchableHighlight>
         </Left>
 
-        <Body style={{ flex: 3 }}>
+        <Body style={styles.body}>
           <Title>{this.props.title} </Title>
-          <Subtitle style={{ color: 'white' }}>{this.props.googleUser.email || 'not found'}</Subtitle>
+          <Subtitle style={{ color: 'white' }}>
+            {this.props.googleUser.email || 'not found'}
+          </Subtitle>
         </Body>
 
-        <Right>
+        <Right style={{ flex: 2 }}>
           <Button transparent dark onPress={() => this.signOut()}>
             <Text>Log out</Text>
           </Button>

--- a/src/components/AppHeader/AppHeader.styles.js
+++ b/src/components/AppHeader/AppHeader.styles.js
@@ -13,6 +13,10 @@ export default StyleSheet.create({
     width: 40,
     borderRadius: 20
   },
+  body: {
+    flex: 4,
+    alignItems: 'center'
+  },
   subTitleText: {
     color: '#ddd'
   },

--- a/src/components/UserSignIn/UserSignInConnected.js
+++ b/src/components/UserSignIn/UserSignInConnected.js
@@ -1,6 +1,10 @@
 import { connect } from 'react-redux';
 import UserSignIn from './UserSignIn';
-import { UserSignIn_onSuccess, UserSignIn_onError, UserSignIn_logOut } from '../../redux/actions/UserSignIn/UserSignInActions';
+import {
+  UserSignIn_onSuccess,
+  UserSignIn_onError,
+  UserSignIn_logOut
+} from '../../redux/actions/UserSignIn/UserSignInActions';
 
 // const mapStateToProps = () => {};
 

--- a/src/routes/AppStackNavigator.js
+++ b/src/routes/AppStackNavigator.js
@@ -1,10 +1,11 @@
 import { createStackNavigator, createAppContainer } from 'react-navigation';
-import { HomeScreen, SignInScreen } from '../screens';
+import { HomeScreen, SignInScreen, AddWordScreen } from '../screens';
 
 const AppStackNavigator = createStackNavigator(
   {
     Home: { screen: HomeScreen },
-    SignIn: { screen: SignInScreen }
+    SignIn: { screen: SignInScreen },
+    AddWord: { screen: AddWordScreen }
   },
   {
     initialRouteName: 'SignIn',

--- a/src/screens/AddWord/AddWord.js
+++ b/src/screens/AddWord/AddWord.js
@@ -1,0 +1,142 @@
+import React, { Component } from 'react';
+import {
+  Container,
+  Content,
+  Form,
+  Item,
+  Label,
+  Input,
+  Text,
+  Textarea,
+  Button,
+  Segment,
+  Icon,
+  Spinner
+} from 'native-base';
+import { Alert } from 'react-native';
+import { PropTypes } from 'prop-types';
+import AppHeader from '../../components/AppHeader/AppHeaderConnected';
+import styles from './AddWord.styles';
+
+class AddWordScreen extends Component {
+  state = {
+    word: '',
+    meaning: '',
+    example: '',
+    comments: '',
+    showAlert: false
+  };
+
+  render() {
+    return (
+      <Container>
+        <AppHeader title="My Vocabulary" navigation={this.props.navigation} />
+        <Content padder contentContainerStyle={styles.contentContainer}>
+          <Segment style={styles.segment}>
+            <Button first>
+              <Text>Add a word</Text>
+            </Button>
+          </Segment>
+          <Form style={styles.form}>
+            <Item floatingLabel style={[styles.rowSpan1]}>
+              <Label>word</Label>
+              <Input value={this.state.word} onChangeText={txt => this.onTextChange('word', txt)} />
+            </Item>
+
+            {/* eslint-disable */}
+            {["meaning", "example", "comments"].map(field =>
+              this.renderTextArea(field)
+            )}
+            {/* eslint-enable */}
+
+            <Button
+              iconLeft
+              block
+              style={[styles.rowSpan1, styles.button]}
+              disabled={this.state.showAlert}
+              onPress={this.postWord}>
+              {/* eslint-disable */}
+              {this.state.showAlert ? (
+                <Spinner color="red" />
+              ) : (
+                <Icon name="add" />
+              )}
+              {/* eslint-enable */}
+
+              <Text>Add word to my vocabulary</Text>
+            </Button>
+          </Form>
+        </Content>
+      </Container>
+    );
+  }
+
+  /**
+   * @name postWord
+   * @description function to call onPress of Add Word button of the form
+   */
+  postWord = () => {
+    this.setState({ showAlert: true });
+    this.showAlert(this.state.word, 'to-do: Add word to Vocab DynamoDB table');
+  };
+
+  /**
+   * @name onTextChange
+   * @description function to call onChangeText event of text inputs
+   *              to update the corresponding state value
+   * @param fieldName name of the input whose text value has been changed
+   * @param value value of the input field
+   */
+  onTextChange = (fieldName, value) => {
+    this.setState({
+      [fieldName]: value
+    });
+  };
+
+  /**
+   * @name renderTextArea
+   * @description returns TextArea element for the specified field
+   * @param fieldName name for the textarea field
+   */
+  renderTextArea = fieldName => (
+    <Textarea
+      rowSpan={3}
+      bordered
+      placeholder={fieldName}
+      key={fieldName}
+      style={styles.rowSpan3}
+      value={this.state[fieldName]}
+      onChangeText={txt => this.onTextChange(fieldName, txt)}
+    />
+  );
+
+  /**
+   * @name showAlert
+   * @description show alert box
+   * @param title title of the alert box
+   * @param message message of the alert box
+   */
+  showAlert = (title, message) =>
+    Alert.alert(
+      title,
+      message,
+      [
+        {
+          text: 'OK',
+          onPress: () => {
+            this.setState({ showAlert: false });
+            this.props.navigation.navigate('Home');
+          }
+        }
+      ],
+      {
+        cancelable: false
+      }
+    );
+}
+
+AddWordScreen.propTypes = {
+  navigation: PropTypes.object.isRequired
+};
+
+export default AddWordScreen;

--- a/src/screens/AddWord/AddWord.js
+++ b/src/screens/AddWord/AddWord.js
@@ -31,12 +31,18 @@ class AddWordScreen extends Component {
     return (
       <Container>
         <AppHeader title="My Vocabulary" navigation={this.props.navigation} />
+
+        <Segment>
+          <Item style={{ flex: 1 }} />
+          <Button first last style={styles.segmentButton}>
+            <Text>Add a word</Text>
+          </Button>
+          <Item onPress={() => this.props.navigation.navigate('Home')} style={styles.closeIconItem}>
+            <Icon name="close" style={styles.closeIcon} />
+          </Item>
+        </Segment>
+
         <Content padder contentContainerStyle={styles.contentContainer}>
-          <Segment style={styles.segment}>
-            <Button first>
-              <Text>Add a word</Text>
-            </Button>
-          </Segment>
           <Form style={styles.form}>
             <Item floatingLabel style={[styles.rowSpan1]}>
               <Label>word</Label>
@@ -91,6 +97,15 @@ class AddWordScreen extends Component {
     this.setState({
       [fieldName]: value
     });
+  };
+
+  /**
+   * @name onCancel
+   * @description function to call on press of cancel button
+   */
+  onCancelPress = () => {
+    // console.log('in cancel');
+    this.props.navigation.navigate('Home');
   };
 
   /**

--- a/src/screens/AddWord/AddWord.styles.js
+++ b/src/screens/AddWord/AddWord.styles.js
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    justifyContent: 'center'
+  },
+  segment: {
+    flex: 1
+  },
+  form: {
+    flex: 9,
+    marginBottom: 20
+  },
+  rowSpan1: {
+    flex: 1,
+    marginTop: 10
+  },
+  rowSpan3: {
+    flex: 4,
+    marginTop: 10
+  },
+  button: {
+    marginTop: 10
+  }
+});

--- a/src/screens/AddWord/AddWord.styles.js
+++ b/src/screens/AddWord/AddWord.styles.js
@@ -1,16 +1,24 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet } from "react-native";
 
 export default StyleSheet.create({
   contentContainer: {
     flex: 1,
-    justifyContent: 'center'
+    justifyContent: "center"
   },
-  segment: {
-    flex: 1
+  segmentButton: {
+    flex: 1,
+    justifyContent: "center"
   },
   form: {
     flex: 9,
     marginBottom: 20
+  },
+  closeIconItem: {
+    flex: 1,
+    justifyContent: "flex-end"
+  },
+  closeIcon: {
+    color: "red"
   },
   rowSpan1: {
     flex: 1,

--- a/src/screens/Home/Home.js
+++ b/src/screens/Home/Home.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import PropTypes from 'prop-types';
-import { Container, Content, List, ListItem, Text } from 'native-base';
+import { Container, Content, List, ListItem, Text, Fab, Icon } from 'native-base';
 import { AppHeader } from '../../components';
 import styles from './Home.styles';
 
@@ -25,10 +25,24 @@ class HomeScreen extends Component {
               </ListItem>
             </List>
           </View>
+
+          <Fab
+            active
+            direction="up"
+            containerStyle={{}}
+            style={{ backgroundColor: '#5067FF' }}
+            position="bottomRight"
+            onPress={this.onFabClick}>
+            <Icon ios="ios-add" android="md-add" style={{ fontSize: 30 }} />
+          </Fab>
         </Content>
       </Container>
     );
   }
+
+  onFabClick = () => {
+    this.props.navigation.navigate('AddWord');
+  };
 }
 
 HomeScreen.propTypes = {

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,2 +1,3 @@
 export { default as HomeScreen } from './Home/Home';
 export { default as SignInScreen } from './SignIn/SignIn';
+export { default as AddWordScreen } from './AddWord/AddWord';


### PR DESCRIPTION

## Story or Defect Link

['Add a word' screen component](https://medium.com/fullstack-with-react-native-aws-serverless-and/add-a-word-screen-component-cf30dec4c4a7)

## Description

- added 'Add Word' screen component
- added it as a screen in AppStackNavigator
- added FAB on Home screen, on press of FAB, navigate to AddWord screen
- AddWord screen is currently a static form, its not yet connected with API to upload the word to db.

## Screenshots

![8](https://user-images.githubusercontent.com/13605214/51063817-44958880-15c2-11e9-9e53-accc15f4f07f.gif)


## Checklist:

- [x] Console Logs removed
- [x] style guidelines followed
- [x] appropriate code comments have been added 

## PR Reviews

- [x] Dev LGTM
- [x] Design LGTM
